### PR TITLE
Move items to config

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -21,30 +21,11 @@ from src.server.redis_manager import (
     status_store,
     update_client_status,
 )
+from src.shared.utils.config import FRONTEND_BUILD_DIR, CORS_ALLOWED_ORIGINS # Updated import
 from src.shared.utils.logging import get_logger
 
 # Initialize logger
 logger = get_logger(__name__)
-
-# Define frontend directory path
-# Assumes 'frontend-command-centre' is at the root of the workspace,
-# and 'server.py' is in 'src/server/'
-FRONTEND_BUILD_DIR = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__), "..", "..", "frontend-command-centre", "dist"
-    )
-)
-if not os.path.exists(FRONTEND_BUILD_DIR):
-    logger.warning(
-        f"Frontend build directory not found: {FRONTEND_BUILD_DIR}. "
-        "The frontend will not be served until it is built and "
-        "placed in the correct location."
-    )
-elif not os.path.exists(os.path.join(FRONTEND_BUILD_DIR, "index.html")):
-    logger.warning(
-        f"index.html not found in frontend build directory: {FRONTEND_BUILD_DIR}. "
-        "The frontend may not be served correctly."
-    )
 
 # Store active connections, distinguishing between roles
 worker_connections: dict[str, WebSocket] = {}
@@ -127,13 +108,7 @@ app = FastAPI(lifespan=lifespan)
 # to this backend.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",  # Vite default dev port
-        "http://127.0.0.1:5173",
-        "http://localhost:3000",  # Common React dev port (e.g. Create React App)
-        "http://127.0.0.1:3000",
-        # Add your production frontend URL here when you deploy
-    ],
+    allow_origins=CORS_ALLOWED_ORIGINS, # Updated to use the imported variable
     allow_credentials=True,
     allow_methods=["*"],  # Allows all standard HTTP methods
     allow_headers=["*"],  # Allows all headers

--- a/src/shared/utils/config.py
+++ b/src/shared/utils/config.py
@@ -2,17 +2,38 @@
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
 from dotenv import load_dotenv
 
+from src.shared.utils.logging import get_logger
+
+# Define project root
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
 # Load environment variables from .env file
-env_path = Path(__file__).parent.parent / ".env"
+env_path = PROJECT_ROOT / ".env"
 load_dotenv(dotenv_path=env_path)
+
+# Initialize logger
+logger = get_logger(__name__)
 
 # Logging Configuration
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 JSON_LOGS = os.getenv("JSON_LOGS", "false").lower() == "true"
+
+# CORS Configuration
+_cors_allowed_origins_str = os.getenv("CORS_ALLOWED_ORIGINS")
+if _cors_allowed_origins_str and _cors_allowed_origins_str.strip():
+    CORS_ALLOWED_ORIGINS: List[str] = [
+        origin.strip() for origin in _cors_allowed_origins_str.split(",")
+    ]
+else:
+    CORS_ALLOWED_ORIGINS: List[str] = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+logger.info(f"CORS allowed origins: {CORS_ALLOWED_ORIGINS}")
 
 # Redis Configuration
 REDIS_CONFIG: dict[str, Any] = {
@@ -31,3 +52,12 @@ SERVER_CONFIG: dict[str, Any] = {
 # Environment
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 IS_PRODUCTION = ENVIRONMENT == "production"
+
+# Frontend Configuration
+FRONTEND_BUILD_PATH_FROM_ROOT = os.getenv("FRONTEND_BUILD_PATH_FROM_ROOT", "frontend-command-centre/dist")
+FRONTEND_BUILD_DIR = PROJECT_ROOT / FRONTEND_BUILD_PATH_FROM_ROOT
+
+if not FRONTEND_BUILD_DIR.exists():
+    logger.warning(f"Frontend build directory not found: {FRONTEND_BUILD_DIR}. Frontend will not be served.")
+elif not (FRONTEND_BUILD_DIR / "index.html").exists():
+    logger.warning(f"index.html not found in frontend build directory: {FRONTEND_BUILD_DIR}. Frontend may not be served correctly.")


### PR DESCRIPTION
Refactor: Centralize backend configuration

Moves FRONTEND_BUILD_DIR and CORS_ALLOWED_ORIGINS to be configurable via a .env file.

Key changes:
- Added a .env file at the project root to store environment-specific configurations.
- Updated `src/shared/utils/config.py` to:
  - Load the .env file from the project root.
  - Read `FRONTEND_BUILD_PATH_FROM_ROOT` and construct an absolute `FRONTEND_BUILD_DIR`. Includes path validation and logging.
  - Read `CORS_ALLOWED_ORIGINS` (comma-separated string) and parse it into a list. Includes logging of loaded origins.
- Updated `src/server/server.py` to:
  - Import `FRONTEND_BUILD_DIR` and `CORS_ALLOWED_ORIGINS` from the shared config.
  - Remove the hardcoded definition of `FRONTEND_BUILD_DIR` and its associated checks.
  - Use the configured `CORS_ALLOWED_ORIGINS` in the CORSMiddleware.
- Reviewed `server.py` for other potential hardcoded configurations; none were deemed high-priority for this change.

This change allows for easier configuration of the frontend build directory and CORS settings without modifying the server code, improving deployment flexibility.